### PR TITLE
prevent layer off retrigger when layer switch is released before button

### DIFF
--- a/src/main/java/frc/util/Layer.java
+++ b/src/main/java/frc/util/Layer.java
@@ -75,7 +75,8 @@ public class Layer {
   }
 
   /**
-   * Combines a {@link Trigger} with the layer root provided that the layer switch is activated.
+   * Combines a {@link Trigger} with the layer switch to form a virtual trigger that is only true
+   * when the layer switch is true and the trigger is true.
    *
    * @param trigger the {@link Trigger} that is used in tandem with the layer for the virtual
    *     Trigger
@@ -87,8 +88,8 @@ public class Layer {
   }
 
   /**
-   * Combines a {@link BooleanSupplier} with the layer root provided that the layer switch is
-   * activated.
+   * Combines a {@link BooleanSupplier} with the layer switch to form a virtual trigger that is only
+   * true when the layer switch is true and the trigger is true.
    *
    * @param Trigger the {@link BooleanSupplier} that is used in tandem with the layer for the
    *     virtual Trigger
@@ -100,7 +101,10 @@ public class Layer {
   }
 
   /**
-   * Combines a {@link Trigger} with the layer root provided that the layer switch is not activated.
+   * Combines a {@link Trigger} with the layer switch to form a virtual trigger that is only true
+   * when the layer switch is false and the trigger is true. Additionally, the virtual trigger will
+   * be false if the layer switch was released but the trigger was still pressed, until the trigger
+   * is released.
    *
    * @param trigger the {@link Trigger} that is used in tandem with the layer for the virtual
    *     Trigger
@@ -134,8 +138,10 @@ public class Layer {
   }
 
   /**
-   * Combines a {@link BooleanSupplier} with the layer root provided that the layer switch is not
-   * activated.
+   * Combines a {@link BooleanSupplier} with the layer switch to form a virtual trigger that is only
+   * true when the layer switch is false and the trigger is true. Additionally, the virtual trigger
+   * will be false if the layer switch was released but the trigger was still pressed, until the
+   * trigger is released.
    *
    * @param Trigger the {@link BooleanSupplier} that is used in tandem with the layer for the
    *     virtual Trigger

--- a/src/test/java/frc/util/LayerTests.java
+++ b/src/test/java/frc/util/LayerTests.java
@@ -163,4 +163,62 @@ public class LayerTests {
         buttonALayerOff,
         "buttonALayerOff should be true because the button is pressed and the layer is off");
   }
+
+  @UtilTest
+  public void pressingLayerOffButtonRepeatedlyWorks() {
+    for (int i = 0; i < 3; i++) {
+      buttonAVal = true;
+      eventLoop.poll();
+      assertTrue(buttonALayerOff, "buttonALayerOff should be true because the button is pressed");
+      assertFalse(buttonALayerOn, "buttonALayerOn should be false because the layer is off");
+      buttonAVal = false;
+      eventLoop.poll();
+      assertFalse(
+          buttonALayerOff, "buttonALayerOff should be false because the button is released");
+      assertFalse(
+          buttonALayerOn,
+          "buttonALayerOn should be false because the layer is off and button is released");
+    }
+  }
+
+  @UtilTest
+  public void pressingLayerOnButtonRepeatedlyWorks() {
+    switchVal = true;
+    eventLoop.poll();
+    for (int i = 0; i < 3; i++) {
+      buttonAVal = true;
+      eventLoop.poll();
+      assertFalse(buttonALayerOff, "buttonALayerOff should be false because the layer is on");
+      assertTrue(buttonALayerOn, "buttonALayerOn should be true because the button is pressed");
+      buttonAVal = false;
+      eventLoop.poll();
+      assertFalse(
+          buttonALayerOff,
+          "buttonALayerOff should be false because the layer is on and button is released");
+      assertFalse(
+          buttonALayerOn,
+          "buttonALayerOn should be false because the layer is on and button is released");
+    }
+  }
+
+  @UtilTest
+  public void
+      releasingAndRepressingLayerSwitchWhileHoldingTriggerReTriggersLayerOnButDoesNotTriggerLayerOff() {
+    buttonAVal = true;
+    eventLoop.poll();
+    assertTrue(buttonALayerOff, "buttonALayerOff should be true because the button is pressed");
+    assertFalse(buttonALayerOn, "buttonALayerOn should be false because the layer is off");
+    for (int i = 0; i < 3; i++) {
+      switchVal = true;
+      eventLoop.poll();
+      assertFalse(buttonALayerOff, "buttonALayerOff should be false because the layer is on");
+      assertTrue(buttonALayerOn, "buttonALayerOn should be true because the button is pressed");
+      switchVal = false;
+      eventLoop.poll();
+      assertFalse(buttonALayerOn, "buttonALayerOn should be false because the layer is off");
+      assertFalse(
+          buttonALayerOff,
+          "buttonALayerOff should be false because the button is still pressed and the layer is off");
+    }
+  }
 }

--- a/src/test/java/frc/util/LayerTests.java
+++ b/src/test/java/frc/util/LayerTests.java
@@ -3,21 +3,25 @@ package frc.util;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import edu.wpi.first.wpilibj.event.EventLoop;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.UtilTest;
 import org.junit.jupiter.api.BeforeEach;
 
 public class LayerTests {
+  private EventLoop eventLoop = new EventLoop();
+
   private boolean switchVal = false;
-  private Trigger layerSwitch = new Trigger(() -> switchVal);
+  private Trigger layerSwitch = new Trigger(eventLoop, () -> switchVal);
 
   private boolean buttonAVal = false;
-  private Trigger buttonA = new Trigger(() -> buttonAVal);
+  private Trigger buttonA = new Trigger(eventLoop, () -> buttonAVal);
 
   private boolean buttonBVal = false;
-  private Trigger buttonB = new Trigger(() -> buttonBVal);
+  private Trigger buttonB = new Trigger(eventLoop, () -> buttonBVal);
 
-  private Layer layer = new Layer(layerSwitch);
+  private Layer layer = new Layer(eventLoop, layerSwitch);
 
   private Trigger buttonALayerOff = layer.off(buttonA);
   private Trigger buttonALayerOn = layer.on(buttonA);
@@ -30,11 +34,23 @@ public class LayerTests {
     switchVal = false;
     buttonAVal = false;
     buttonBVal = false;
+
+    // if you never bind to a trigger, it won't fire
+    // triggers are lazy
+    // our triggers have state, so we need to bind them to something to test them
+    buttonALayerOff.onTrue(new InstantCommand());
+    buttonALayerOn.onTrue(new InstantCommand());
+    buttonBLayerOff.onTrue(new InstantCommand());
+    buttonBLayerOn.onTrue(new InstantCommand());
+
+    // we need to run the event loop once to initialize the triggers
+    eventLoop.poll();
   }
 
   @UtilTest
   public void buttonTrueWhenLayerOffAndButtonOn() {
     buttonAVal = true;
+    eventLoop.poll();
     assertTrue(buttonALayerOff);
   }
 
@@ -47,9 +63,42 @@ public class LayerTests {
   @UtilTest
   public void buttonTrueConditionalOnLayer() {
     buttonBVal = true;
+    eventLoop.poll();
     assertFalse(buttonALayerOff);
     assertFalse(buttonBLayerOn);
     switchVal = true;
+    eventLoop.poll();
     assertTrue(buttonBLayerOn);
+  }
+
+  @UtilTest
+  public void buttonBecomesTrueWhenLayerAndButtonTurnsOn() {
+    assertFalse(buttonALayerOff);
+    assertFalse(buttonALayerOn);
+    switchVal = true;
+    eventLoop.poll();
+    assertFalse(buttonALayerOff);
+    assertFalse(buttonALayerOn);
+    buttonAVal = true;
+    eventLoop.poll();
+    assertFalse(buttonALayerOff);
+    assertTrue(buttonALayerOn);
+  }
+
+  @UtilTest
+  public void releasingLayerSwitchDoesNotTriggerLayerOffButtonAndCancelsLayerOn() {
+    switchVal = true;
+    eventLoop.poll();
+    buttonAVal = true;
+    eventLoop.poll();
+    assertTrue(
+        buttonALayerOn,
+        "buttonALayerOn should be true because the layer is on and the button is pressed");
+    switchVal = false;
+    eventLoop.poll();
+    assertFalse(buttonALayerOn, "buttonALayerOn should be false because the layer is off");
+    assertFalse(
+        buttonALayerOff,
+        "buttonALayerOff should be false even though the button is pressed, because the button and layer haven't been released");
   }
 }

--- a/src/test/java/frc/util/LayerTests.java
+++ b/src/test/java/frc/util/LayerTests.java
@@ -101,4 +101,66 @@ public class LayerTests {
         buttonALayerOff,
         "buttonALayerOff should be false even though the button is pressed, because the button and layer haven't been released");
   }
+
+  @UtilTest
+  public void pressingLayerSwitchAndButtonAtSameTimeTriggersLayerOnButton() {
+    buttonAVal = true;
+    switchVal = true;
+    eventLoop.poll();
+    assertTrue(
+        buttonALayerOn,
+        "buttonALayerOn should be true because the layer is on and the button is pressed");
+  }
+
+  @UtilTest
+  public void releasingLayerSwitchAndButtonAllowsOffLayerToBePressedAgain() {
+    switchVal = true;
+    eventLoop.poll();
+    buttonAVal = true;
+    eventLoop.poll();
+    switchVal = false;
+    eventLoop.poll();
+    assertFalse(buttonALayerOn, "buttonALayerOn should be false because the layer is off");
+    assertFalse(
+        buttonALayerOff,
+        "buttonALayerOff should be false even though the button is pressed, because the button and layer haven't been released");
+    buttonAVal = false;
+    eventLoop.poll();
+    assertFalse(
+        buttonALayerOff, "buttonALayerOff should be false because the button isn't pressed");
+
+    buttonAVal = true;
+    eventLoop.poll();
+    assertTrue(
+        buttonALayerOff,
+        "buttonALayerOff should be true because the button is pressed and the layer is off");
+  }
+
+  @UtilTest
+  public void layerOffRemainsOffForAsLongAsButtonIsNotReleasedAfterLayerOn() {
+    switchVal = true;
+    buttonAVal = true;
+    eventLoop.poll();
+    switchVal = false;
+    eventLoop.poll();
+    assertFalse(
+        buttonALayerOff,
+        "buttonALayerOff should be false because the button hasn't been released since layer usage");
+    eventLoop.poll();
+    assertFalse(
+        buttonALayerOff,
+        "buttonALayerOff should be false because the button hasn't been released since layer usage");
+    eventLoop.poll();
+    assertFalse(
+        buttonALayerOff,
+        "buttonALayerOff should be false because the button hasn't been released since layer usage");
+    buttonAVal = false;
+    eventLoop.poll();
+    assertFalse(buttonALayerOff, "buttonALayerOff should be false because the button is released");
+    buttonAVal = true;
+    eventLoop.poll();
+    assertTrue(
+        buttonALayerOff,
+        "buttonALayerOff should be true because the button is pressed and the layer is off");
+  }
 }


### PR DESCRIPTION
per the issue we were having today, should prevent the layeroff from triggering when you release the layerswitch before the button, until you release the button too